### PR TITLE
prueba padres

### DIFF
--- a/apps/padres/views.py
+++ b/apps/padres/views.py
@@ -58,8 +58,11 @@ class PadreView(APIView):
             
         paginator = CustomPageNumberPagination()
         page = paginator.paginate_queryset(queryset, request)
-        serializer = PadreSerializer(page, many=True)
-        return paginator.get_paginated_response(serializer.data)
+        if page is not None:
+            serializer = PadreSerializer(page, many=True)
+            return paginator.get_paginated_response(serializer.data)
+        serializer = PadreSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     def post(self, request):
         if not es_admin_o_super(request.user):
@@ -70,7 +73,6 @@ class PadreView(APIView):
 
         if picture_file:
             try:
-                # ✅ Configurar Cloudinary antes de usarlo
                 cloudinary.config(
                     cloud_name=settings.CLOUDINARY_STORAGE['CLOUD_NAME'],
                     api_key=settings.CLOUDINARY_STORAGE['API_KEY'],
@@ -87,6 +89,7 @@ class PadreView(APIView):
                 data['picture'] = resultado.get('secure_url')
 
             except Exception as e:
+                print(e)
                 return Response({"error": str(e)}, status=400)
 
         serializer = PadreSerializer(data=data)
@@ -94,6 +97,7 @@ class PadreView(APIView):
             serializer.save(isActive=True)
             return Response(serializer.data, status=201)
 
+        print(serializer.errors)
         return Response(serializer.errors, status=400)
 
     def put(self, request, pk):


### PR DESCRIPTION
This pull request makes several improvements to the `apps/padres/views.py` file, primarily focusing on enhancing error handling, logging, and pagination logic in the API views. The key changes ensure that paginated and non-paginated responses are handled correctly, and add useful debugging output for error cases during POST requests.

**Pagination and response improvements:**

* Improved the `get` method to handle both paginated and non-paginated responses, ensuring that if pagination is not applied, the full queryset is serialized and returned.

**Error handling and debugging:**

* Added `print` statements to log exceptions and serializer errors in the `post` method, which will help with debugging issues during file upload or data validation.
* Removed a redundant comment about Cloudinary configuration, cleaning up the code.